### PR TITLE
git ignoring the folders AutogluonModels, generated when running the …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# models created when running examples
+*AutogluonModels*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Updating gitignore to ensure the AutogluonModels folders do not get added and committed by error