### PR TITLE
if data is a list, we do not check dimensionality

### DIFF
--- a/autotst/splitted_sets.py
+++ b/autotst/splitted_sets.py
@@ -52,7 +52,7 @@ class SplittedSets:
         labels for testing set.
         """
 
-        if X.shape[1:] != Y.shape[1:]:
+        if type(X) != list and X.shape[1:] != Y.shape[1:]:
             raise ValueError("X and Y should be samples of items of same dimension")
 
         if split_ratio < 0 or split_ratio > 1:


### PR DESCRIPTION
In the digits example, for the AutoGluon Image classifier, the data is a list of paths. 
If that is the case, we should not check that the second dimension is the same, since it would raise an error.